### PR TITLE
update hierarchy methods to have *donburi.Entry as data

### DIFF
--- a/features/hierarchy/children.go
+++ b/features/hierarchy/children.go
@@ -5,13 +5,13 @@ import (
 )
 
 type childrenData struct {
-	Children []donburi.Entity
+	Children []*donburi.Entry
 }
 
 var childrenComponent = donburi.NewComponentType[childrenData]()
 
 // GetChildren returns children of the entry.
-func GetChildren(entry *donburi.Entry) ([]donburi.Entity, bool) {
+func GetChildren(entry *donburi.Entry) ([]*donburi.Entry, bool) {
 	if cd, ok := getChildrenData(entry); ok {
 		return cd.Children, true
 	}
@@ -19,7 +19,7 @@ func GetChildren(entry *donburi.Entry) ([]donburi.Entity, bool) {
 }
 
 // MustGetChildren returns children of the entry.
-func MustGetChildren(entry *donburi.Entry) []donburi.Entity {
+func MustGetChildren(entry *donburi.Entry) []*donburi.Entry {
 	c := donburi.Get[childrenData](entry, childrenComponent)
 	return c.Children
 }

--- a/features/hierarchy/example_test.go
+++ b/features/hierarchy/example_test.go
@@ -37,12 +37,12 @@ func TestHierarchy(t *testing.T) {
 		},
 	})
 
-	if p, ok := GetParent(ce); p != pe.Entity() || !ok {
-		t.Errorf("expected parent entity %d, got %d", pe.Entity(), p)
+	if p, ok := GetParent(ce); p.Entity() != pe.Entity() || !ok {
+		t.Errorf("expected parent entity %d, got %d", pe.Entity(), p.Entity())
 	}
 
-	if p, ok := GetParent(ge); p != ce.Entity() || !ok {
-		t.Errorf("expected parent entity %d, got %d", ce.Entity(), p)
+	if p, ok := GetParent(ge); p.Entity() != ce.Entity() || !ok {
+		t.Errorf("expected parent entity %d, got %d", ce.Entity(), p.Entity())
 	}
 
 	if HasParent(pe) {
@@ -53,13 +53,13 @@ func TestHierarchy(t *testing.T) {
 	if !ok {
 		t.Errorf("expected children, got nil")
 	}
-	if children[0] != ce.Entity() {
-		t.Errorf("expected child entity %d, got %d", ce.Entity(), children[0])
+	if children[0].Entity() != ce.Entity() {
+		t.Errorf("expected child entity %d, got %d", ce.Entity(), children[0].Entity())
 	}
 
 	children, ok = GetChildren(ce)
-	if children[0] != ge.Entity() {
-		t.Errorf("expected child entity %d, got %d", ge.Entity(), children[0])
+	if children[0].Entity() != ge.Entity() {
+		t.Errorf("expected child entity %d, got %d", ge.Entity(), children[0].Entity())
 	}
 
 	pe.Remove()
@@ -189,8 +189,8 @@ func testChildren(t *testing.T, tests []childrenTest) {
 			t.Errorf("expected %d children, got %d", len(test.Children), len(children))
 		}
 		for i, c := range children {
-			if c != test.Children[i].Entity() {
-				t.Errorf("expected child entity %d, got %d", test.Children[i].Entity(), c)
+			if c.Entity() != test.Children[i].Entity() {
+				t.Errorf("expected child entity %d, got %d", test.Children[i].Entity(), c.Entity())
 			}
 		}
 	}

--- a/features/hierarchy/hierarchy.go
+++ b/features/hierarchy/hierarchy.go
@@ -26,13 +26,13 @@ func (hs *hierarchySystem) RemoveChildren(ecs *ecs.ECS) {
 			return
 		}
 		if pd, ok := getParentData(entry); ok {
-			if ecs.World.Valid(pd.Parent) {
+			if pd.Parent.Valid() {
 				return
 			}
 			c, ok := GetChildren(entry)
 			if ok {
 				for _, e := range c {
-					RemoveRecursive(ecs.World.Entry(e))
+					RemoveRecursive(e)
 				}
 			}
 			entry.Remove()

--- a/features/transform/transform.go
+++ b/features/transform/transform.go
@@ -66,7 +66,7 @@ func SetWorldPosition(entry *donburi.Entry, pos dmath.Vec2) {
 		return
 	}
 
-	parent := entry.World.Entry(hierarchy.MustGetParent(entry))
+	parent := hierarchy.MustGetParent(entry)
 	parentPos := WorldPosition(parent)
 	d.LocalPosition.X = pos.X - parentPos.X
 	d.LocalPosition.Y = pos.Y - parentPos.Y
@@ -79,7 +79,7 @@ func WorldPosition(entry *donburi.Entry) dmath.Vec2 {
 		return d.LocalPosition
 	}
 
-	parent := entry.World.Entry(hierarchy.MustGetParent(entry))
+	parent := hierarchy.MustGetParent(entry)
 	parentPos := WorldPosition(parent)
 	return parentPos.Add(&d.LocalPosition)
 }
@@ -92,7 +92,7 @@ func SetWorldRotation(entry *donburi.Entry, rotation float64) {
 		return
 	}
 
-	parent := entry.World.Entry(hierarchy.MustGetParent(entry))
+	parent := hierarchy.MustGetParent(entry)
 	d.LocalRotation = rotation - WorldRotation(parent)
 }
 
@@ -104,7 +104,7 @@ func SetWorldScale(entry *donburi.Entry, scale dmath.Vec2) {
 		return
 	}
 
-	parent := entry.World.Entry(hierarchy.MustGetParent(entry))
+	parent := hierarchy.MustGetParent(entry)
 	parentScale := WorldScale(parent)
 	d.LocalScale.X = scale.X / parentScale.X
 	d.LocalScale.Y = scale.Y / parentScale.Y
@@ -117,7 +117,7 @@ func WorldRotation(entry *donburi.Entry) float64 {
 		return d.LocalRotation
 	}
 
-	parent := entry.World.Entry(hierarchy.MustGetParent(entry))
+	parent := hierarchy.MustGetParent(entry)
 	rot := WorldRotation(parent)
 	return rot + d.LocalRotation
 }
@@ -129,7 +129,7 @@ func WorldScale(entry *donburi.Entry) dmath.Vec2 {
 		return d.LocalScale
 	}
 
-	parent := entry.World.Entry(hierarchy.MustGetParent(entry))
+	parent := hierarchy.MustGetParent(entry)
 	parentScale := WorldScale(parent)
 	return parentScale.Mul(&d.LocalScale)
 }


### PR DESCRIPTION
Update hierarchy component data to hold []*donburi.Entry instead of []donburi.Entity for consistency.