### PR TITLE
Add a transform.ChangeParent(child, parent, keepWorldPosition) Function 

### DIFF
--- a/features/hierarchy/example_test.go
+++ b/features/hierarchy/example_test.go
@@ -172,6 +172,57 @@ func TestFindChildren(t *testing.T) {
 	}
 }
 
+func TestChangeParent(t *testing.T) {
+	w := donburi.NewWorld()
+
+	parent1 := donburi.NewTag().SetName("parent1")
+	parent2 := donburi.NewTag().SetName("parent2")
+	child := donburi.NewTag().SetName("child")
+
+	p1e := w.Entry(w.Create(parent1))
+	p2e := w.Entry(w.Create(parent2))
+	ce := w.Entry(w.Create(child))
+
+	// no parent exists
+	ChangeParent(ce, p1e)
+	testChildren(t, []childrenTest{
+		{
+			Parent:   p1e,
+			Children: []*donburi.Entry{ce},
+		},
+		{
+			Parent:   p2e,
+			Children: []*donburi.Entry{},
+		},
+	})
+
+	// change to same parent
+	ChangeParent(ce, p1e)
+	testChildren(t, []childrenTest{
+		{
+			Parent:   p1e,
+			Children: []*donburi.Entry{ce},
+		},
+		{
+			Parent:   p2e,
+			Children: []*donburi.Entry{},
+		},
+	})
+
+	// change parent
+	ChangeParent(ce, p2e)
+	testChildren(t, []childrenTest{
+		{
+			Parent:   p1e,
+			Children: []*donburi.Entry{},
+		},
+		{
+			Parent:   p2e,
+			Children: []*donburi.Entry{ce},
+		},
+	})
+}
+
 type childrenTest struct {
 	Parent   *donburi.Entry
 	Children []*donburi.Entry
@@ -192,42 +243,4 @@ func testChildren(t *testing.T, tests []childrenTest) {
 			}
 		}
 	}
-}
-
-func TestChangeParent(t *testing.T) {
-	w := donburi.NewWorld()
-
-	parent1 := donburi.NewTag().SetName("parent1")
-	parent2 := donburi.NewTag().SetName("parent2")
-	child := donburi.NewTag().SetName("child")
-
-	p1e := w.Entry(w.Create(parent1))
-	p2e := w.Entry(w.Create(parent2))
-	ce := w.Entry(w.Create(child))
-
-	ChangeParent(ce, p1e)
-	testChildren(t, []childrenTest{
-		{
-			Parent:   p1e,
-			Children: []*donburi.Entry{ce},
-		},
-		{
-			Parent:   p2e,
-			Children: []*donburi.Entry{},
-		},
-	})
-
-	SetParent(ce, p1e)
-	ChangeParent(ce, p2e)
-
-	testChildren(t, []childrenTest{
-		{
-			Parent:   p1e,
-			Children: []*donburi.Entry{},
-		},
-		{
-			Parent:   p2e,
-			Children: []*donburi.Entry{ce},
-		},
-	})
 }

--- a/features/hierarchy/example_test.go
+++ b/features/hierarchy/example_test.go
@@ -193,3 +193,41 @@ func testChildren(t *testing.T, tests []childrenTest) {
 		}
 	}
 }
+
+func TestChangeParent(t *testing.T) {
+	w := donburi.NewWorld()
+
+	parent1 := donburi.NewTag().SetName("parent1")
+	parent2 := donburi.NewTag().SetName("parent2")
+	child := donburi.NewTag().SetName("child")
+
+	p1e := w.Entry(w.Create(parent1))
+	p2e := w.Entry(w.Create(parent2))
+	ce := w.Entry(w.Create(child))
+
+	ChangeParent(ce, p1e)
+	testChildren(t, []childrenTest{
+		{
+			Parent:   p1e,
+			Children: []*donburi.Entry{ce},
+		},
+		{
+			Parent:   p2e,
+			Children: []*donburi.Entry{},
+		},
+	})
+
+	SetParent(ce, p1e)
+	ChangeParent(ce, p2e)
+
+	testChildren(t, []childrenTest{
+		{
+			Parent:   p1e,
+			Children: []*donburi.Entry{},
+		},
+		{
+			Parent:   p2e,
+			Children: []*donburi.Entry{ce},
+		},
+	})
+}

--- a/features/hierarchy/example_test.go
+++ b/features/hierarchy/example_test.go
@@ -190,10 +190,6 @@ func TestChangeParent(t *testing.T) {
 			Parent:   p1e,
 			Children: []*donburi.Entry{ce},
 		},
-		{
-			Parent:   p2e,
-			Children: []*donburi.Entry{},
-		},
 	})
 
 	// change to same parent
@@ -202,10 +198,6 @@ func TestChangeParent(t *testing.T) {
 		{
 			Parent:   p1e,
 			Children: []*donburi.Entry{ce},
-		},
-		{
-			Parent:   p2e,
-			Children: []*donburi.Entry{},
 		},
 	})
 

--- a/features/hierarchy/parent.go
+++ b/features/hierarchy/parent.go
@@ -89,6 +89,39 @@ func HasParent(entry *donburi.Entry) bool {
 	return entry.HasComponent(parentComponent)
 }
 
+// ChangeParent changes a parent of the entry.
+func ChangeParent(child *donburi.Entry, newParent *donburi.Entry) {
+	if !newParent.Valid() {
+		panic("newParent is not valid")
+	}
+	if !child.Valid() {
+		panic("child is not valid")
+	}
+	if !newParent.HasComponent(childrenComponent) {
+		newParent.AddComponent(childrenComponent)
+	}
+
+	if oldParent, ok := GetParent(child); ok {
+		if oldParent == newParent {
+			return
+		}
+
+		if oldParent.Valid() {
+			oldChildren := donburi.Get[childrenData](oldParent, childrenComponent)
+			for i, c := range oldChildren.Children {
+				if c == child {
+					oldChildren.Children = append(oldChildren.Children[:i], oldChildren.Children[i+1:]...)
+					break
+				}
+			}
+		}
+
+		child.RemoveComponent(parentComponent)
+	}
+
+	SetParent(child, newParent)
+}
+
 func getParentData(entry *donburi.Entry) (*parentData, bool) {
 	if HasParent(entry) {
 		p := donburi.Get[parentData](entry, parentComponent)

--- a/features/transform/transform.go
+++ b/features/transform/transform.go
@@ -41,6 +41,7 @@ func AppendChild(parent, child *donburi.Entry, keepWorldPosition bool) {
 	SetParent(child, parent, keepWorldPosition)
 }
 
+// ChangeParent changes parent of the entry.
 func ChangeParent(child, parent *donburi.Entry, keepWorldPosition bool) {
 	if !child.HasComponent(Transform) {
 		panic("entry does not have transform component")

--- a/features/transform/transform.go
+++ b/features/transform/transform.go
@@ -41,6 +41,15 @@ func AppendChild(parent, child *donburi.Entry, keepWorldPosition bool) {
 	SetParent(child, parent, keepWorldPosition)
 }
 
+func ChangeParent(child, parent *donburi.Entry, keepWorldPosition bool) {
+	if !child.HasComponent(Transform) {
+		panic("entry does not have transform component")
+	}
+	RemoveParent(child, keepWorldPosition)
+	hierarchy.ChangeParent(child, parent)
+	SetParent(child, parent, keepWorldPosition)
+}
+
 // SetParent sets parent to the entry.
 func SetParent(entry, parent *donburi.Entry, keepWorldPosition bool) {
 	if !entry.HasComponent(Transform) {
@@ -71,6 +80,30 @@ func GetParent(entry *donburi.Entry) (*donburi.Entry, bool) {
 		return nil, false
 	}
 	return hierarchy.GetParent(entry)
+}
+
+// RemoveParent removes parent of the entry.
+func RemoveParent(entry *donburi.Entry, keepWorldPosition bool) {
+	d := GetTransform(entry)
+	if !d.hasParent {
+		return
+	}
+	parent, _ := GetParent(entry)
+	d.hasParent = false
+	if keepWorldPosition {
+		parentPos := WorldPosition(parent)
+
+		d.LocalPosition = d.LocalPosition.Add(parentPos)
+		d.LocalRotation += WorldRotation(parent)
+
+		ws := WorldScale(parent)
+		if ws.X != 0 {
+			d.LocalScale.X = d.LocalScale.X * ws.X
+		}
+		if ws.Y != 0 {
+			d.LocalScale.Y = d.LocalScale.Y * ws.Y
+		}
+	}
 }
 
 // GetChildren returns children of the entry.

--- a/features/transform/transform_test.go
+++ b/features/transform/transform_test.go
@@ -43,9 +43,9 @@ func TestTransform(t *testing.T) {
 	transform.RemoveParent(parent, false)
 
 	testWorldTransform(t, child, &testTransform{
-		Position: dmath.Vec2{X: 2, Y: 4},
-		Rotation: 90,
-		Scale:    dmath.Vec2{X: 4, Y: 9},
+		Position: dmath.Vec2{X: 1, Y: 2},
+		Rotation: 180,
+		Scale:    dmath.Vec2{X: 2, Y: 3},
 	})
 }
 

--- a/features/transform/transform_test.go
+++ b/features/transform/transform_test.go
@@ -39,6 +39,14 @@ func TestTransform(t *testing.T) {
 		Rotation: 180,
 		Scale:    dmath.Vec2{X: 2, Y: 3},
 	})
+
+	transform.RemoveParent(parent, false)
+
+	testWorldTransform(t, child, &testTransform{
+		Position: dmath.Vec2{X: 2, Y: 4},
+		Rotation: 90,
+		Scale:    dmath.Vec2{X: 4, Y: 9},
+	})
 }
 
 func TestTransformKeepWorldPosition(t *testing.T) {
@@ -58,6 +66,14 @@ func TestTransformKeepWorldPosition(t *testing.T) {
 	})
 
 	transform.AppendChild(parent, child, true)
+
+	testWorldTransform(t, child, &testTransform{
+		Position: dmath.Vec2{X: 1, Y: 2},
+		Rotation: 90,
+		Scale:    dmath.Vec2{X: 1.5, Y: 1.5},
+	})
+
+	transform.RemoveParent(parent, true)
 
 	testWorldTransform(t, child, &testTransform{
 		Position: dmath.Vec2{X: 1, Y: 2},


### PR DESCRIPTION
This is a first draft for a function that allows to change the parent.

I will improve the tests and fix bugs if necessary.

The transform.SetParent changes only the positioning but not the actual parent, that happens only in the ApplyChildren.

My new RemoveParent also only changes the positioning. To avoid confusion I'm thinking about renaming this to RemoveParentTransformation or staying in the same naming scheme but making the function private.