### PR TITLE
fix: Only draw initialized layers

### DIFF
--- a/ecs/ecs.go
+++ b/ecs/ecs.go
@@ -72,6 +72,9 @@ func (ecs *ECS) DrawLayer(l LayerID, screen *ebiten.Image) {
 // Draw executes all draw systems.
 func (ecs *ECS) Draw(screen *ebiten.Image) {
 	for _, l := range ecs.layers {
+		if l == nil {
+			continue
+		}
 		l.draw(ecs, screen)
 	}
 }

--- a/ecs/ecs_test.go
+++ b/ecs/ecs_test.go
@@ -112,6 +112,17 @@ func TestECSLayer(t *testing.T) {
 	}
 }
 
+func TestEmptyDefaultLayer(t *testing.T) {
+	world := donburi.NewWorld()
+	ecs := NewECS(world)
+
+	TestLayer := LayerID(1)
+
+	ecs.AddRenderer(TestLayer, func(ecs *ECS, image *ebiten.Image) {})
+
+	ecs.Draw(ebiten.NewImage(1, 1))
+}
+
 var (
 	testUpdatedIndex int
 	testDrawedIndex  int


### PR DESCRIPTION
This fixes an issue where we'd attempt to call draw on a nil layer. I think this was only an issue around trying to ignore the `Default` layer. 