### PR TITLE
Implement hierarchy.RemoveParent

### DIFF
--- a/features/hierarchy/parent.go
+++ b/features/hierarchy/parent.go
@@ -41,9 +41,36 @@ func RemoveChildrenRecursive(entry *donburi.Entry) {
 	}
 }
 
+func RemoveParent(entry *donburi.Entry) {
+	if !HasParent(entry) {
+		return
+	}
+
+	parent, ok := GetParent(entry)
+	if !ok || !parent.Valid() {
+		entry.RemoveComponent(parentComponent)
+		return
+	}
+
+	if children, ok := GetChildren(parent); ok {
+		newChildren := make([]*donburi.Entry, 0, len(children))
+		for _, child := range children {
+			if child != entry {
+				newChildren = append(newChildren, child)
+			}
+		}
+		donburi.SetValue(parent, childrenComponent, childrenData{
+			Children: newChildren,
+		})
+	}
+
+	entry.RemoveComponent(parentComponent)
+}
+
 // RemoveRecursive removes the entry recursively.
 func RemoveRecursive(entry *donburi.Entry) {
 	RemoveChildrenRecursive(entry)
+	RemoveParent(entry)
 	entry.Remove()
 }
 

--- a/features/transform/transform.go
+++ b/features/transform/transform.go
@@ -90,6 +90,7 @@ func RemoveParent(entry *donburi.Entry, keepWorldPosition bool) {
 		return
 	}
 	parent, _ := GetParent(entry)
+	hierarchy.RemoveParent(entry)
 	d.hasParent = false
 	if keepWorldPosition {
 		parentPos := WorldPosition(parent)


### PR DESCRIPTION
Hey! I've been dealing with a very strange bug where one entity gets multiple parents. After wrestling with it for a while, I realized the issue was that Donburi recycled an entity ID for another object, which was already a child.

I realized that `RemoveRecursive` doesn't delete the objects from the child list, and `transform.RemoveParent` doesn't either.

This should fix this, but I'm not sure if it's clear how to use hierarchy and transform now 🤔 Perhaps we could merge the code to `transform` to make it clearer what's going on there. I'm not sure if it makes sense to use hierarchy without transforms.